### PR TITLE
Improve parsing of nested binary expressions

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,14 +1,15 @@
-//@formatter:off
 {
   "env": {
+    "es6": true,
     "browser": true,
-    "node": true,
-    "es6": false
+    "node": true
   },
+
   "globals": {
     "jQuery": false,
     "$": false
   },
+
   "rules": {
     "strict": 0,
     "no-underscore-dangle": 0,
@@ -16,7 +17,7 @@
     "indent": [2, 4],
     "brace-style": [2, "1tbs"],
     // make this one a two when closer to production
-    "no-alert": 2
+    "no-alert": 2,
+    "no-var": 2
   }
 }
-//@formatter:on

--- a/README.md
+++ b/README.md
@@ -10,6 +10,11 @@ Full API documentation and examples is available on the [Documentation](https://
 To include the library in your application, you can either reference the `.js` files under the `dist` folder or use the JSPM / Node 
 modular inclusion discussed on the [Documentation](https://github.com/jadrake75/odata-filter-parser/blob/master/doc/Intro.md) page.
 
+### Compatibility
+It is required to use a supported ES6 level of JavaScript (supported by all current browsers and NodeJS supported versions) with
+version 0.4.0 or higher.
+
+
 ## Including the Library with Aurelia CLI
 The new Aurelia CLI will have difficulty resolving the dependencies from the require statements and try and resolve odata-filter under src vs the distribution folder.  To resolve this, 
 use the following configuration in the dependencies section of the aurelia.json file:

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -50,7 +50,7 @@ gulp.task('copy', function() {
 gulp.task('eslint', function () {
     return gulp.src('src/**')
         .pipe(eslint({
-            configFile: '.eslintrc'
+            configFile: '.eslintrc.json'
         }))
         .pipe(eslint.format());
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,12 @@
 {
   "name": "odata-filter-parser",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "version": "0.3.0",
+      "name": "odata-filter-parser",
+      "version": "0.3.1",
       "license": "Apache-2.0",
       "devDependencies": {
         "@babel/core": "^7.4.0",
@@ -3588,7 +3589,6 @@
         "anymatch": "^2.0.0",
         "async-each": "^1.0.1",
         "braces": "^2.3.2",
-        "fsevents": "^1.2.7",
         "glob-parent": "^3.1.0",
         "inherits": "^2.0.3",
         "is-binary-path": "^1.0.0",
@@ -4327,8 +4327,7 @@
         "esprima": "^4.0.1",
         "estraverse": "^5.2.0",
         "esutils": "^2.0.2",
-        "optionator": "^0.8.1",
-        "source-map": "~0.6.1"
+        "optionator": "^0.8.1"
       },
       "bin": {
         "escodegen": "bin/escodegen.js",
@@ -5763,9 +5762,9 @@
       }
     },
     "node_modules/gulp-eslint/node_modules/ansi-regex": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-      "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.1.tgz",
+      "integrity": "sha512-ILlv4k/3f6vfQ4OoP2AGvirOktlQ98ZEL1k9FaQjxa3L1abBgbuTDAdPOpvbGncC0BTVQrl+OM8xZGK6tWXt7g==",
       "dev": true,
       "engines": {
         "node": ">=6"
@@ -7635,7 +7634,6 @@
         "@types/node": "*",
         "anymatch": "^3.0.3",
         "fb-watchman": "^2.0.0",
-        "fsevents": "^2.3.2",
         "graceful-fs": "^4.2.4",
         "jest-regex-util": "^27.4.0",
         "jest-serializer": "^27.4.0",
@@ -9425,9 +9423,9 @@
       }
     },
     "node_modules/minimist": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
+      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
       "dev": true
     },
     "node_modules/mixin-deep": {
@@ -11603,9 +11601,9 @@
       }
     },
     "node_modules/table/node_modules/ansi-regex": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-      "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.1.tgz",
+      "integrity": "sha512-ILlv4k/3f6vfQ4OoP2AGvirOktlQ98ZEL1k9FaQjxa3L1abBgbuTDAdPOpvbGncC0BTVQrl+OM8xZGK6tWXt7g==",
       "dev": true,
       "engines": {
         "node": ">=6"
@@ -17047,9 +17045,9 @@
           "dev": true
         },
         "ansi-regex": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.1.tgz",
+          "integrity": "sha512-ILlv4k/3f6vfQ4OoP2AGvirOktlQ98ZEL1k9FaQjxa3L1abBgbuTDAdPOpvbGncC0BTVQrl+OM8xZGK6tWXt7g==",
           "dev": true
         },
         "cross-spawn": {
@@ -19833,9 +19831,9 @@
       }
     },
     "minimist": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
+      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
       "dev": true
     },
     "mixin-deep": {
@@ -21561,9 +21559,9 @@
       },
       "dependencies": {
         "ansi-regex": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.1.tgz",
+          "integrity": "sha512-ILlv4k/3f6vfQ4OoP2AGvirOktlQ98ZEL1k9FaQjxa3L1abBgbuTDAdPOpvbGncC0BTVQrl+OM8xZGK6tWXt7g==",
           "dev": true
         },
         "emoji-regex": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "odata-filter-parser",
-  "version": "0.3.1",
+  "version": "0.4.0",
   "description": "Library for parsing and building OData filter strings",
   "main": "index.js",
   "scripts": {

--- a/src/odata-parser.js
+++ b/src/odata-parser.js
@@ -14,7 +14,7 @@
  limitations under the License.
  */
 
-var Operators = {
+const Operators = {
     EQUALS: 'eq',
     AND: 'and',
     OR: 'or',
@@ -34,7 +34,7 @@ var Operators = {
      * @return {Boolean} whether the operation is an unary operation.
      */
     isUnary: function (op) {
-        var value = false;
+        let value = false;
         if (op === Operators.IS_NULL) {
             value = true;
         }
@@ -58,7 +58,7 @@ var Operators = {
  * @returns {Predicate}
  * @constructor
  */
-var Predicate = function (config) {
+const Predicate = function (config) {
     if (!config) {
         config = {};
     }
@@ -80,16 +80,16 @@ Predicate.concat = function (operator, p) {
             msg: 'The operator is not representative of a logical operator.'
         };
     }
-    var result;
-    var arr = [];
+    let result;
+    let arr = [];
     if (p instanceof Array) {
         arr = p;
     } else {
-        for (var i = 1; i < arguments.length; i++) {
+        for (let i = 1; i < arguments.length; i++) {
             arr.push(arguments[i]);
         }
     }
-    var len = arr.length;
+    const len = arr.length;
     result = new Predicate({
         subject: arr[0],
         operator: operator
@@ -97,8 +97,8 @@ Predicate.concat = function (operator, p) {
     if (len === 2) {
         result.value = arr[len - 1];
     } else {
-        var a = [];
-        for (var j = 1; j < len; j++) {
+        let a = [];
+        for (let j = 1; j < len; j++) {
             a.push(arr[j]);
         }
         result.value = Predicate.concat(operator, a);
@@ -125,7 +125,7 @@ Predicate.prototype.flatten = function (result) {
  * @return {String} The compliant ODATA query string
  */
 Predicate.prototype.serialize = function () {
-    var retValue = '';
+    let retValue = '';
     if (this.operator) {
         if (this.subject === undefined || this.subject === null) {
             throw {
@@ -142,10 +142,10 @@ Predicate.prototype.serialize = function () {
         }
         retValue = '(';
         if (this.operator === Operators.LIKE) {
-            var op = 'contains';
-            var lastIndex = this.value.lastIndexOf('*');
-            var index = this.value.indexOf('*');
-            var v = this.value;
+            let op = 'contains';
+            const lastIndex = this.value.lastIndexOf('*');
+            const index = this.value.indexOf('*');
+            let v = this.value;
             if (index === 0 && lastIndex !== this.value.length - 1) {
                 op = 'endswith';
                 v = v.substring(1);
@@ -167,7 +167,7 @@ Predicate.prototype.serialize = function () {
                     };
                 }
                 retValue += ' ';
-                var val = typeof this.value;
+                const val = typeof this.value;
                 if (val === 'string') {
                     retValue += '\'' + this.value + '\'';
                 } else if (val === 'number' || val === 'boolean') {
@@ -191,11 +191,11 @@ Predicate.prototype.serialize = function () {
     return retValue;
 };
 
-var ODataParser = function () {
+const ODataParser = function () {
 
     "use strict";
 
-    var REGEX = {
+    const REGEX = {
         parenthesis: /^([(](.*)[)])$/,
         andor: /^(.*?) (or|and)+ (.*)$/,
         op: /(\w*) (eq|gt|lt|ge|le|ne) (datetimeoffset'(.*)'|'(.*)'|[0-9]*)/,
@@ -205,7 +205,7 @@ var ODataParser = function () {
     };
 
     function buildLike(match, key) {
-        var right = (key === 'startsWith') ? match[2] + '*' : (key === 'endsWith') ? '*' + match[2] : '*' + match[2] + '*';
+        let right = (key === 'startsWith') ? match[2] + '*' : (key === 'endsWith') ? '*' + match[2] : '*' + match[2] + '*';
         return new Predicate({
             subject: match[1],
             operator: Operators.LIKE,
@@ -214,14 +214,14 @@ var ODataParser = function () {
     }
 
     function parseFragment(filter) {
-        var found = false;
-        var obj = null;
-        for (var key in REGEX) {
-            var regex = REGEX[key];
+        let found = false;
+        let obj = null;
+        for (let key in REGEX) {
+            const regex = REGEX[key];
             if (found) {
                 break;
             }
-            var match = filter.match(regex);
+            let match = filter.match(regex);
             if (match) {
                 switch (regex) {
                 case REGEX.parenthesis:
@@ -241,8 +241,8 @@ var ODataParser = function () {
                         value: (match[3].indexOf('\'') === -1) ? +match[3] : match[3]
                     });
                     if (typeof obj.value === 'string') {
-                        var quoted = obj.value.match(/^'(.*)'$/);
-                        var m = obj.value.match(/^datetimeoffset'(.*)'$/);
+                        const quoted = obj.value.match(/^'(.*)'$/);
+                        const m = obj.value.match(/^datetimeoffset'(.*)'$/);
                         if (quoted && quoted.length > 1) {
                             obj.value = quoted[1];
                         } else if (m && m.length > 1) {
@@ -310,8 +310,8 @@ var ODataParser = function () {
             if (!filterStr || filterStr === '') {
                 return null;
             }
-            var filter = filterStr.trim();
-            var obj = {};
+            let filter = filterStr.trim();
+            let obj = {};
             if (filter.length > 0) {
                 obj = parseFragment(filter);
             }

--- a/test/unit/odata-parser.spec.js
+++ b/test/unit/odata-parser.spec.js
@@ -144,6 +144,37 @@ describe('ODataParser Tests', done => {
 
         });
 
+        it('Nested binary expressions', () => {
+            var s = "(((district eq 'all') or (district eq 'palilula')) and ((malfunctions eq 'true') or (maintenance eq 'true')))";
+            var obj = parser.parse(s);
+            var subject = obj.subject;
+            var value = obj.value;
+            var subjectNestedSubject = subject.subject;
+            var subjectNestedValue = subject.value;
+            var valueNestedSubject = value.subject;
+            var valueNestedValue = value.value;
+
+            expect(obj.operator).toEqual("and");
+            expect(subject.operator).toEqual("or");
+            expect(value.operator).toEqual("or");
+
+            expect(subjectNestedSubject.subject).toEqual("district");
+            expect(subjectNestedSubject.value).toEqual("all");
+            expect(subjectNestedSubject.operator).toEqual("eq");
+
+            expect(subjectNestedValue.subject).toEqual("district");
+            expect(subjectNestedValue.value).toEqual("palilula");
+            expect(subjectNestedValue.operator).toEqual("eq");
+
+            expect(valueNestedSubject.subject).toEqual("malfunctions");
+            expect(valueNestedSubject.value).toEqual("true");
+            expect(valueNestedSubject.operator).toEqual("eq");
+
+            expect(valueNestedValue.subject).toEqual("maintenance");
+            expect(valueNestedValue.value).toEqual("true");
+            expect(valueNestedValue.operator).toEqual("eq");
+        });
+
         it('Verify startsWith condition', () => {
             var s = "startswith(name,'Ja')";
             var obj = parser.parse(s);


### PR DESCRIPTION
Nested parenthesis cannot be handled by regex only. Additional parsing logic is required, and provided solution represents a simple lexical analyser that can handle symbols: `(`, `)`, and `'`. 